### PR TITLE
Specify exact package version for R-based callers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@ successful-run-settings/
 tests/coverage_html/
 ! tests/coverage_html/.gitkeep
 *.gz
-docker-images/*
-!docker-images/*/Dockerfile
 *.html
 
 # Byte-compiled / optimized / DLL files

--- a/docker-images/copywriter/Dockerfile
+++ b/docker-images/copywriter/Dockerfile
@@ -1,6 +1,10 @@
-# later versions have errors in dependency installation for CopywriteR
-FROM r-base:3.2.5  
+FROM r-base:3.5.1  
 
-RUN R -e "install.packages(c('optparse', 'dplyr', 'tidyr', 'stringr')); source('http://bioconductor.org/biocLite.R'); biocLite('CopywriteR');"
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libcurl4-openssl-dev libxml2-dev libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN R -e "install.packages(c('optparse', 'dplyr', 'tidyr', 'stringr', 'BiocManager')); \
+    BiocManager::install('CopywriteR', version = '3.8');" 
 
 CMD ["bash"]

--- a/docker-images/exome-depth/Dockerfile
+++ b/docker-images/exome-depth/Dockerfile
@@ -1,9 +1,11 @@
 FROM r-base:3.5.1
 
-RUN apt-get update \ 
-    && apt-get install -y --no-install-recommends libcurl4-openssl-dev libxml2-dev \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libcurl4-openssl-dev libxml2-dev libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN R -e 'install.packages(c("optparse", "ExomeDepth"))'
+RUN R -e 'install.packages(c("BiocManager", "devtools", "optparse")) ; \
+    BiocManager::install("GenomicAlignments", version = "3.8") ; \
+    devtools::install_version("ExomeDepth", version = "1.1.10", repos = "http://cran.ma.imperial.ac.uk")'
 
 WORKDIR /mnt/cnv-caller-resources/exome-depth/

--- a/scripts/copywriter.py
+++ b/scripts/copywriter.py
@@ -19,7 +19,7 @@ class Copywriter(base_classes.BaseCNVTool):
         self.run_type = "copywriter"
         super().__init__(capture, gene, start_time, normal_panel=normal_panel)
         self.extra_db_fields = ["num.mark", "unknown", "seg.mean", "control_id"]
-        self.settings = {**self.settings, "docker_image": "stefpiatek/copywriter:2.2.0"}
+        self.settings = {**self.settings, "docker_image": "stefpiatek/copywriter:2.14.1"}
 
     def parse_output_file(self, file_path, sample_id):
         cnvs = []


### PR DESCRIPTION
Happily, also managed to get the latest version of copywriter to work because of new bioconductor method for installing packages. 