### PR TITLE
Allow high depth samples

### DIFF
--- a/cnv-caller-resources/codex2/run_codex.R
+++ b/cnv-caller-resources/codex2/run_codex.R
@@ -61,27 +61,21 @@ gc_qc <- ref_qc$gc
 
 write.table(qcmat, file = file.path(opt$output_path, "qcmat.txt"), sep = "\t", quote = FALSE, row.names = FALSE)
 
+
 # Library size estimate for each sample
 Y_non_zero <- Y_qc[apply(Y_qc, 1, function(x) {!any(x == 0)}), ]
-pseudo_sample <- apply(Y_non_zero, 1, function(x) {prod(x) ^ (1 / length(x))})
+pseudo_sample <- apply(Y_non_zero, 1, function(x) {prod(x ^ (1 / length(x)))})  # changed to avoid product being maximum value r can take (> 1.7e308)
 N <- apply(apply(Y_non_zero, 2, function(x) {x / pseudo_sample}), 2, median)
-plot(N, apply(Y, 2, sum), xlab="Estimated library size factor", ylab="Total sum of reads")
 
 # Reference sample normalisation
 norm_object <- normalize_codex2_ns(Y_qc = Y_qc, gc_qc = gc_qc, K = 1:10, norm_index = normal_panel_index, N = N)
+
 
 Yhat <- norm_object$Yhat
 AIC <- norm_object$AIC
 BIC <- norm_object$BIC
 RSS <- norm_object$RSS
 
-# Number of latent factors
-choiceofK(AIC, BIC, RSS, K = 1:10 , filename = "codex2_choiceofK.pdf")
-par(mfrow = c(1, 3))
-plot(1:10, RSS, type = "b", xlab = "Number of latent variables", pch=20)
-plot(1:10, AIC, type = "b", xlab = "Number of latent variables", pch=20)
-plot(1:10, BIC, type = "b", xlab = "Number of latent variables", pch=20)
-par(mfrow = c(1, 1))
 
 # CBS segmentation per gene for targeted seq
 source("/mnt/cnv-caller-resources/codex2/segment_targeted.R")

--- a/scripts/xhmm.py
+++ b/scripts/xhmm.py
@@ -5,8 +5,8 @@ Defaults used from XHMM documentation https://atgu.mgh.harvard.edu/xhmm/tutorial
 - no parallism at the moment
 - no repeat masking using PLINK/Seq
 - Altered filtering to allow for high read depth
-   - Max target read depth: 1000
-   - Max sample mean read depth: 1000
+   - Max target read depth: 100,000
+   - Max sample mean read depth: 100,000
    - Max sample SD read depth: 300
 """
 
@@ -57,7 +57,7 @@ class XHMM(base_classes.BaseCNVTool):
             )
 
         sample_vcf = self.run_docker_subprocess(
-            ["bcftools", "view", "-c1", "-Ov", "-s", sample_id, f"{docker_file_path}.gz"],
+            ["bcftools", "view", "-c1", "-Ov", "--force-samples", "-s", sample_id, f"{docker_file_path}.gz"],
             docker_image="halllab/bcftools:v1.9",
             stdout=subprocess.PIPE,
         )
@@ -171,11 +171,11 @@ class XHMM(base_classes.BaseCNVTool):
                 "--minMeanTargetRD",
                 "10",
                 "--maxMeanTargetRD",
-                "1000",
+                "100000",
                 "--minMeanSampleRD",
                 "25",
                 "--maxMeanSampleRD",
-                "1000",
+                "100000",
                 "--maxSdSampleRD",
                 "300",
                 "-o",


### PR DESCRIPTION
- CODEX2 reached infinite values for a calculation so had to change order of product, making the values smaller before taking their product
- XHMM excluded values based on having too high a read depth, so altered the maximum values for this